### PR TITLE
Backport updates

### DIFF
--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -1,8 +1,8 @@
 class I386ElfBinutils < Formula
   desc "GNU Binutils targetting i386-elf"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://sourceware.org/pub/binutils/releases/binutils-2.23.2.tar.bz2"
-  version "2.23.2"
+  url "https://sourceware.org/pub/binutils/releases/binutils-2.20.1.tar.bz2"
+  version "2.20.1"
  
 
   def install

--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -1,9 +1,9 @@
 class I386ElfBinutils < Formula
   desc "GNU Binutils targetting i386-elf"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://sourceware.org/pub/binutils/releases/binutils-2.30.tar.xz"
-  version "2.30"
-  sha256 "6e46b8aeae2f727a36f0bd9505e405768a72218f1796f0d09757d45209871ae6"
+  url "https://sourceware.org/pub/binutils/releases/binutils-2.23.2.tar.bz2"
+  version "2.23.2"
+ 
 
   def install
     mkdir "binutils-build" do

--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -1,8 +1,8 @@
 class I386ElfBinutils < Formula
   desc "GNU Binutils targetting i386-elf"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://sourceware.org/pub/binutils/releases/binutils-2.24.tar.bz2"
-  version "2.24"
+  url "https://sourceware.org/pub/binutils/releases/binutils-2.31.tar.xz"
+  version "2.31"
  
 
   def install

--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -1,8 +1,8 @@
 class I386ElfBinutils < Formula
   desc "GNU Binutils targetting i386-elf"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://sourceware.org/pub/binutils/releases/binutils-2.20.1.tar.bz2"
-  version "2.20.1"
+  url "https://sourceware.org/pub/binutils/releases/binutils-2.22.tar.bz2"
+  version "2.22"
  
 
   def install

--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -1,8 +1,8 @@
 class I386ElfBinutils < Formula
   desc "GNU Binutils targetting i386-elf"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://sourceware.org/pub/binutils/releases/binutils-2.22.tar.bz2"
-  version "2.22"
+  url "https://sourceware.org/pub/binutils/releases/binutils-2.24.tar.bz2"
+  version "2.24"
  
 
   def install

--- a/Formula/i386-elf-binutils.rb
+++ b/Formula/i386-elf-binutils.rb
@@ -3,6 +3,7 @@ class I386ElfBinutils < Formula
   homepage "https://www.gnu.org/software/binutils/"
   url "https://sourceware.org/pub/binutils/releases/binutils-2.31.tar.xz"
   version "2.31"
+  sha256 "231036df7ef02049cdbff0681f4575e571f26ea8086cf70c2dcd3b6c0f4216bf"
  
 
   def install

--- a/Formula/i386-elf-gcc.rb
+++ b/Formula/i386-elf-gcc.rb
@@ -1,9 +1,9 @@
 class I386ElfGcc < Formula
   desc "GNU Compiler Collection targetting i386-elf"
   homepage "https://gcc.gnu.org"
-  url "http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
-  version "7.3.0"
-  sha256 "832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
+  url "http://ftpmirror.gnu.org/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
+  version "9.2.0"
+  sha256 "ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206"
 
 
   depends_on "gmp" => :build

--- a/Formula/i386-elf-gcc.rb
+++ b/Formula/i386-elf-gcc.rb
@@ -1,9 +1,9 @@
 class I386ElfGcc < Formula
   desc "GNU Compiler Collection targetting i386-elf"
   homepage "https://gcc.gnu.org"
-  url "http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
-  version "7.3.0"
-  sha256 "832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-6.3.0/gcc-6.3.0.tar.bz2"
+  version "6.3.0"
+  sha256 "f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f"
 
   depends_on "gmp" => :build
   depends_on "i386-elf-binutils"

--- a/Formula/i386-elf-gcc.rb
+++ b/Formula/i386-elf-gcc.rb
@@ -1,8 +1,9 @@
 class I386ElfGcc < Formula
   desc "GNU Compiler Collection targetting i386-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-4.8.2/gcc-4.8.2.tar.bz2"
-  version "4.8.2"
+  url "http://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
+  version "7.3.0"
+  sha256 "832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
 
 
   depends_on "gmp" => :build

--- a/Formula/i386-elf-gcc.rb
+++ b/Formula/i386-elf-gcc.rb
@@ -1,9 +1,9 @@
 class I386ElfGcc < Formula
   desc "GNU Compiler Collection targetting i386-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-6.3.0/gcc-6.3.0.tar.bz2"
-  version "6.3.0"
-  sha256 "f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-4.8.2/gcc-4.8.2.tar.bz2"
+  version "4.8.2"
+
 
   depends_on "gmp" => :build
   depends_on "i386-elf-binutils"


### PR DESCRIPTION
This commit backports GCC to 9.2.0. Thanks to @ITzTravelInTime for taking the time to do this. Closes #7 