### PR TITLE
Add GCC 12.2 to allow building on Apple ARM chips

### DIFF
--- a/Formula/i386-elf-gcc@11.2.rb
+++ b/Formula/i386-elf-gcc@11.2.rb
@@ -1,9 +1,9 @@
-class I386ElfGcc < Formula
+class I386ElfGccAT112 < Formula
   desc "GNU Compiler Collection targetting i386-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz"
-  version "12.2.0"
-  sha256 "e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-11.2.0/gcc-11.2.0.tar.xz"
+  version "11.2.0"
+  sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   revision 1
 
   depends_on "gmp" => :build

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Default version is marked in bold. For older versions, you must use the
     -   **2.37 (`nativeos/i386-elf-toolchain/i386-elf-binutils`)**
     -   2.36.1 (`nativeos/i386-elf-toolchain/i386-elf-binutils@2.36.1`)
 -   i386-elf-gcc
-    -   **11.2.0 (`nativeos/i386-elf-toolchain/i386-elf-gcc`)**
+    -   **12.2.0 (`nativeos/i386-elf-toolchain/i386-elf-gcc`)**
+    -   11.2.0 (`nativeos/i386-elf-toolchain/i386-elf-gcc@11.2`).
     -   11.1.0 (`nativeos/i386-elf-toolchain/i386-elf-gcc@11.1`).
 -   i386-elf-gdb
     -   **10.2.0 (`nativeos/i386-elf-toolchain/i386-elf-gdb`)**


### PR DESCRIPTION
Fix https://github.com/nativeos/homebrew-i386-elf-toolchain/issues/23